### PR TITLE
Refactoring & using permalinks instead of line references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,23 @@ package manager please see `environment.yml` for a full list of dependencies.
 
 # How to run the code
 
-There are two ways to run our code:-
-* Open the rstudio project covid19model.Rproj file in rstudio and run/source base.r file
-* To run from commandline please enter the cloned directory and type 'Rscript base.r base' in terminal
+## There are two ways to run our code
+1. Open the rstudio project covid19model.Rproj file in rstudio and run/source `base.r` file
+2. To run from commandline please enter the cloned directory and type 'Rscript base.r base' in terminal
+## Results
 * The results are stored in two folders results and figures.
 * Results has the stored stan fits and data used for plotting
 * Figures have the images with daily cases, daily death and Rt for all countries.
 
-## Please note to not make you wait for long we have by default run sampling for short period. To be comparable with report please uncomment the line 206 and comment out line 207. This will run sampling for 4000 iterations with 2000 warmups and 4 chains.
+## Notice
+Please note to not make you wait for long, we have by default run sampling for a short period. 
+ 
+To be comparable with report, in [`base.r`](base.r), uncomment the first line shown below and comment out the second line. Click [here](https://github.com/ImperialCollegeLondon/covid19model/blob/7c35e25340a8067706d548a104eca86169d50b67/base.r#L212-L213) to navigate to the area of interest.
+
+```python
+# fit = sampling(m,data=stan_data,iter=4000,warmup=2000,chains=8,thin=4,control = list(adapt_delta = 0.90, max_treedepth = 10))
+fit = sampling(m,data=stan_data,iter=200,warmup=100,chains=4,thin=4,control = list(adapt_delta = 0.90, max_treedepth = 10))
+```
+This will run sampling for 4000 iterations with 2000 warmups and 8 chains.
+
+You can also limit the number of countries studied by replacing `countries` as shown [here](https://github.com/ImperialCollegeLondon/covid19model/blob/7c35e25340a8067706d548a104eca86169d50b67/base.r#L63).

--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ package manager please see `environment.yml` for a full list of dependencies.
 ## Notice
 Please note to not make you wait for long, we have by default run sampling for a short period. 
  
-To be comparable with report, in [`base.r`](base.r), uncomment the first line shown below and comment out the second line. Click [here](https://github.com/ImperialCollegeLondon/covid19model/blob/7c35e25340a8067706d548a104eca86169d50b67/base.r#L212-L213) to navigate to the area of interest.
-
-```python
-# fit = sampling(m,data=stan_data,iter=4000,warmup=2000,chains=8,thin=4,control = list(adapt_delta = 0.90, max_treedepth = 10))
-fit = sampling(m,data=stan_data,iter=200,warmup=100,chains=4,thin=4,control = list(adapt_delta = 0.90, max_treedepth = 10))
-```
-This will run sampling for 4000 iterations with 2000 warmups and 8 chains.
+To be comparable with report, in [`base.r`](base.r), uncomment the first line and comment out the second line [here](https://github.com/ImperialCollegeLondon/covid19model/blob/7c35e25340a8067706d548a104eca86169d50b67/base.r#L212-L213). This will run sampling for 4000 iterations with 2000 warmups and 8 chains.
 
 You can also limit the number of countries studied by replacing `countries` as shown [here](https://github.com/ImperialCollegeLondon/covid19model/blob/7c35e25340a8067706d548a104eca86169d50b67/base.r#L63).


### PR DESCRIPTION
Line number reference no longer correct, using permalinks.

Added instructions to quicken runs by limiting `countries`.