### PR TITLE
Refactor stan according to issue #33

### DIFF
--- a/base.r
+++ b/base.r
@@ -48,6 +48,7 @@ covariates$self_isolating_if_ill[covariates$self_isolating_if_ill > covariates$l
 
 p <- ncol(covariates) - 1
 forecast = 0
+DEBUG=TRUE
 
 if (Sys.getenv("DEBUG") == "TRUE") {
    DEBUG = TRUE
@@ -67,8 +68,8 @@ if(DEBUG == FALSE) {
 
 dates = list()
 reported_cases = list()
-stan_data = list(M=length(countries),N=NULL,p=p,x1=poly(1:N2,2)[,1],x2=poly(1:N2,2)[,2],
-                 y=NULL,covariate1=NULL,covariate2=NULL,covariate3=NULL,covariate4=NULL,covariate5=NULL,covariate6=NULL,covariate7=NULL,deaths=NULL,f=NULL,
+stan_data = list(M=length(countries),N=NULL,p=p,
+                 y=NULL,x1=NULL,x2=NULL,x3=NULL,x4=NULL,x5=NULL,x6=NULL,x7=NULL,deaths=NULL,f=NULL,
                  N0=6,cases=NULL,LENGTHSCALE=7,SI=serial.interval$fit[1:N2],
                  EpidemicStart = NULL) # N0 = 6 to make it consistent with Rayleigh
 deaths_by_country = list()
@@ -153,50 +154,49 @@ for(Country in countries) {
   stan_data$N = c(stan_data$N,N)
   stan_data$y = c(stan_data$y,y[1]) # just the index case!
   # stan_data$x = cbind(stan_data$x,x)
-  stan_data$covariate1 = cbind(stan_data$covariate1,covariates2[,1])
-  stan_data$covariate2 = cbind(stan_data$covariate2,covariates2[,2])
-  stan_data$covariate3 = cbind(stan_data$covariate3,covariates2[,3])
-  stan_data$covariate4 = cbind(stan_data$covariate4,covariates2[,4])
-  stan_data$covariate5 = cbind(stan_data$covariate5,covariates2[,5])
-  stan_data$covariate6 = cbind(stan_data$covariate6,covariates2[,6])
-  stan_data$covariate7 = cbind(stan_data$covariate7,covariates2[,7]) 
+  stan_data$x1 = cbind(stan_data$x1,covariates2[,1])
+  stan_data$x2 = cbind(stan_data$x2,covariates2[,2])
+  stan_data$x3 = cbind(stan_data$x3,covariates2[,3])
+  stan_data$x4 = cbind(stan_data$x4,covariates2[,4])
+  stan_data$x5 = cbind(stan_data$x5,covariates2[,5])
+  stan_data$x6 = cbind(stan_data$x6,covariates2[,6])
+  stan_data$x7 = cbind(stan_data$x7,covariates2[,7]) 
   stan_data$f = cbind(stan_data$f,f)
   stan_data$deaths = cbind(stan_data$deaths,deaths)
   stan_data$cases = cbind(stan_data$cases,cases)
   
   stan_data$N2=N2
-  stan_data$x=1:N2
   if(length(stan_data$N) == 1) {
     stan_data$N = as.array(stan_data$N)
   }
 }
 
-stan_data$covariate2 = 0 * stan_data$covariate2 # remove travel bans
-stan_data$covariate4 = 0 * stan_data$covariate5 # remove sport
+stan_data$x2 = 0 * stan_data$x2 # remove travel bans
+stan_data$x4 = 0 * stan_data$x5 # remove sport
 
 #stan_data$covariate1 = stan_data$covariate1 # school closure
-stan_data$covariate2 = stan_data$covariate7 # self-isolating if ill
+stan_data$x2 = stan_data$x7 # self-isolating if ill
 #stan_data$covariate3 = stan_data$covariate3 # public events
 # create the `any intervention` covariate
-stan_data$covariate4 = 1*as.data.frame((stan_data$covariate1+
-                                          stan_data$covariate3+
-                                          stan_data$covariate5+
-                                          stan_data$covariate6+
-                                          stan_data$covariate7) >= 1)
-stan_data$covariate5 = stan_data$covariate5 # lockdown
-stan_data$covariate6 = stan_data$covariate6 # social distancing encouraged
-stan_data$covariate7 = 0 # models should only take 6 covariates
+stan_data$x4 = 1*as.data.frame((stan_data$x1+
+                                          stan_data$x3+
+                                          stan_data$x5+
+                                          stan_data$x6+
+                                          stan_data$x7) >= 1)
+stan_data$x5 = stan_data$x5 # lockdown
+stan_data$x6 = stan_data$x6 # social distancing encouraged
+stan_data$x7 = 0 # models should only take 6 covariates
 
 if(DEBUG) {
   for(i in 1:length(countries)) {
     write.csv(
       data.frame(date=dates[[i]],
-                 `school closure`=stan_data$covariate1[1:stan_data$N[i],i],
-                 `self isolating if ill`=stan_data$covariate2[1:stan_data$N[i],i],
-                 `public events`=stan_data$covariate3[1:stan_data$N[i],i],
-                 `government makes any intervention`=stan_data$covariate4[1:stan_data$N[i],i],
-                 `lockdown`=stan_data$covariate5[1:stan_data$N[i],i],
-                 `social distancing encouraged`=stan_data$covariate6[1:stan_data$N[i],i]),
+                 `school closure`=stan_data$x1[1:stan_data$N[i],i],
+                 `self isolating if ill`=stan_data$x2[1:stan_data$N[i],i],
+                 `public events`=stan_data$x3[1:stan_data$N[i],i],
+                 `government makes any intervention`=stan_data$x4[1:stan_data$N[i],i],
+                 `lockdown`=stan_data$x5[1:stan_data$N[i],i],
+                 `social distancing encouraged`=stan_data$x6[1:stan_data$N[i],i]),
       file=sprintf("results/%s-check-dates.csv",countries[i]),row.names=F)
   }
 }

--- a/stan-models/base.stan
+++ b/stan-models/base.stan
@@ -1,19 +1,43 @@
+// functions {
+//     matrix expected_deaths(matrix prediction, matrix f) {
+//         int M = rows(prediction);
+//         int N = cols(prediction);
+//         matrix[M, N] y;
+//         for (m in 1:M) {
+//             y[1, m] = 1e-9;
+// 	        for (i in 2:M) {
+// 	            y[2, m] = 0;
+// 	            for (j in 1:(i - 1)) {
+// 	                y[i, m] += prediction[j, m] * f[i - j, m];
+//                 }
+//             }
+//         }
+//         return y;
+//     }
+// }
+
 data {
     int<lower = 1> M; // number of countries
     int<lower = 1> N0; // number of days for which to impute infections
     int<lower = 1> N[M]; // days of observed data for country m. each entry must be <= N2
     int<lower = 1> N2; // # days of observed data (used in analysis) + # of days to forecast
+    // real<lower=0> x[N2]; // index of days (starting at 1)
     int cases[N2, M]; // reported cases
     int deaths[N2, M]; // reported deaths -- the rows with i > N contain -1 and should be ignored
     matrix[N2, M] f; // h * s
-    matrix[N2, M] covariate1;
-    matrix[N2, M] covariate2;
-    matrix[N2, M] covariate3;
-    matrix[N2, M] covariate4;
-    matrix[N2, M] covariate5;
-    matrix[N2, M] covariate6;
+    matrix[N2, M] x1;
+    matrix[N2, M] x2;
+    matrix[N2, M] x3;
+    matrix[N2, M] x4;
+    matrix[N2, M] x5;
+    matrix[N2, M] x6;
     int EpidemicStart[M];
     real SI[N2]; // fixed pre-calculated SI using emprical data from Neil
+}
+
+transformed data {
+    matrix[N2, M] matrix_1000 = rep_matrix(1000, N2, M);
+    matrix[N2, M] matrix_0 = rep_matrix(0, N2, M);
 }
 
 parameters {
@@ -33,12 +57,12 @@ transformed parameters {
 
     matrix[N2, M] prediction = rep_matrix(0, N2, M);
     matrix[N2, M] E_deaths  = rep_matrix(0, N2, M);
-    matrix[N2, M] Rt = exp(covariate1 * (-alpha[1]) 
-                            + covariate2 * (-alpha[2]) 
-                            + covariate3 * (-alpha[3]) 
-                            + covariate4 * (-alpha[4]) 
-                            + covariate5 * (-alpha[5]) 
-                            + covariate6 * (-alpha[6])); // + GP[i]); // to_vector (x) * time_effect
+    matrix[N2, M] Rt = exp(x1 * (-alpha[1]) 
+                            + x2 * (-alpha[2]) 
+                            + x3 * (-alpha[3]) 
+                            + x4 * (-alpha[4]) 
+                            + x5 * (-alpha[5]) 
+                            + x6 * (-alpha[6])); // + GP[i]); // to_vector (x) * time_effect
     for (m in 1:M) {
         for (i in 1:N0) {
             prediction[i, m] = y[m];
@@ -50,7 +74,13 @@ transformed parameters {
             prediction[i, m] = Rt[i, m] * convolution;
         }
       
-        E_deaths = expected_deaths(prediction, f);
+              E_deaths[1, m]= 1e-9;
+      for (i in 2:N2){
+        E_deaths[i,m]= 0;
+        for(j in 1:(i-1)){
+          E_deaths[i,m] += prediction[j,m]*f[i-j,m];
+        }
+      }
     }
     /* for(m in 1:M) {
         for(i in 1:N[m]) {
@@ -62,8 +92,8 @@ transformed parameters {
 model {
     tau_unit ~ exponential(1); // implies tau ~ exponential(0.03)
     target += -sum(y_raw); // exponential(1) prior on y_raw implies y ~ exponential(1 / tau)
-    phi ~ std_normal();
-    kappa ~ std_normal();
+    kappa_std ~ std_normal();
+    phi_std ~ std_normal();
     mu ~ normal(2.4, kappa); // citation needed 
     alpha ~ gamma(0.5, 1);
     for(m in 1:M) {
@@ -74,16 +104,11 @@ model {
     }
 }
 
-generated_data {
-    matrix[N2, M] matrix_1000 = rep_matrix(1000, N2, M);
-    matrix[N2, M] matrix_0 = rep_matrix(0, N2, M);
-}
-
 generated quantities {
     matrix[N2, M] lp0 = matrix_1000; // log-probability for LOO for the counterfactual model
-    matrix[N2, M] lp1 = matrix_0; // log-probability for LOO for the main model
-    matrix[N2, M] prediction0 = rep_matrix(0, N2, M);
-    matrix[N2, M] E_deaths0  = rep_matrix(0, N2, M);
+    matrix[N2, M] lp1 = matrix_1000; // log-probability for LOO for the main model
+    matrix[N2, M] prediction0 = matrix_0;
+    matrix[N2, M] E_deaths0  = matrix_0;
     for (m in 1:M) {
         prediction0[1:N0, m] = rep_vector(y[m], N0); // learn the number of cases in the first N0 days
         for (i in (N0+1):N2) {
@@ -94,7 +119,13 @@ generated quantities {
             prediction0[i, m] = mu[m] * convolution0;
         } 
       
-        E_deaths0 = expected_deaths(prediction0, f);
+        E_deaths0[1, m]= 1e-9;
+      for (i in 2:N2){
+        E_deaths0[i,m]= 0;
+        for(j in 1:(i-1)){
+          E_deaths0[i,m] += prediction0[j,m]*f[i-j,m];
+        }
+      }
 
         for(i in 1:N[m]) {
             lp0[i, m] = neg_binomial_2_lpmf(deaths[i, m] | E_deaths[i, m], phi); 
@@ -102,21 +133,3 @@ generated quantities {
         }
     }
 }
-
-functions {
-    matrix expected_deaths(matrix prediction, matrix f) {
-        int M = rows(prediction);
-        int N = cols(prediction);
-        matrix[M, N] y;
-        for (m in 1:M) {
-            y[1, m] = NaN;
-	        for (i in 2:M) {
-	            y[2, m] = 0;
-	            for (j in 1:(i - 1)) {
-	                y[i, m] += prediction[j, m] * f[i - j, m];
-                }
-            }
-        }
-        return y;
-    }
-  }

--- a/stan-models/base.stan
+++ b/stan-models/base.stan
@@ -1,106 +1,122 @@
 data {
-  int <lower=1> M; // number of countries
-  int <lower=1> N0; // number of days for which to impute infections
-  int<lower=1> N[M]; // days of observed data for country m. each entry must be <= N2
-  int<lower=1> N2; // days of observed data + # of days to forecast
-  real<lower=0> x[N2]; // index of days (starting at 1)
-  int cases[N2,M]; // reported cases
-  int deaths[N2, M]; // reported deaths -- the rows with i > N contain -1 and should be ignored
-  matrix[N2, M] f; // h * s
-  matrix[N2, M] covariate1;
-  matrix[N2, M] covariate2;
-  matrix[N2, M] covariate3;
-  matrix[N2, M] covariate4;
-  matrix[N2, M] covariate5;
-  matrix[N2, M] covariate6;
-  int EpidemicStart[M];
-  real SI[N2]; // fixed pre-calculated SI using emprical data from Neil
-}
-
-transformed data {
-  real delta = 1e-5;
+    int<lower = 1> M; // number of countries
+    int<lower = 1> N0; // number of days for which to impute infections
+    int<lower = 1> N[M]; // days of observed data for country m. each entry must be <= N2
+    int<lower = 1> N2; // # days of observed data (used in analysis) + # of days to forecast
+    int cases[N2, M]; // reported cases
+    int deaths[N2, M]; // reported deaths -- the rows with i > N contain -1 and should be ignored
+    matrix[N2, M] f; // h * s
+    matrix[N2, M] covariate1;
+    matrix[N2, M] covariate2;
+    matrix[N2, M] covariate3;
+    matrix[N2, M] covariate4;
+    matrix[N2, M] covariate5;
+    matrix[N2, M] covariate6;
+    int EpidemicStart[M];
+    real SI[N2]; // fixed pre-calculated SI using emprical data from Neil
 }
 
 parameters {
-  real<lower=0> mu[M]; // intercept for Rt
-  real<lower=0> alpha[6]; // the hier term
-  real<lower=0> kappa;
-  vector<lower=0>[M] y_raw;
-  real<lower=0> phi;
-  real<lower=0> tau;
+    vector<lower = 0>[M] y_raw;
+    real<lower = 0> mu[M]; // intercept for Rt
+    real<lower = 0> alpha[6]; // the hier term
+    real<lower = 0> kappa_std;
+    real<lower = 0> phi_std;
+    real<lower = 0> tau_unit;
 }
 
 transformed parameters {
+    real<lower = 0> tau = tau_unit / 0.03;
+    real<lower = 0> phi = 5 * phi_std;
+    real<lower = 0> kappa = 0.5 * kappa_std;
     vector<lower = 0>[M] y = tau * y_raw;
-    matrix[N2, M] prediction = rep_matrix(0,N2,M);
-    matrix[N2, M] E_deaths  = rep_matrix(0,N2,M);
-    matrix[N2, M] Rt = rep_matrix(0,N2,M);
-    for (m in 1:M){
-      prediction[1:N0,m] = rep_vector(y[m],N0); // learn the number of cases in the first N0 days
-        Rt[,m] = mu[m] * exp(covariate1[,m] * (-alpha[1]) + covariate2[,m] * (-alpha[2]) +
-        covariate3[,m] * (-alpha[3])+ covariate4[,m] * (-alpha[4]) + covariate5[,m] * (-alpha[5]) + 
-        covariate6[,m] * (-alpha[6])); // + GP[i]); // to_vector(x) * time_effect
-      for (i in (N0+1):N2) {
-        real convolution=0;
-        for(j in 1:(i-1)) {
-          convolution += prediction[j, m]*SI[i-j]; // Correctd 22nd March
-        }
-        prediction[i, m] = Rt[i,m] * convolution;
-      }
-      
-      E_deaths[1, m]= 1e-9;
-      for (i in 2:N2){
-        E_deaths[i,m]= 0;
-        for(j in 1:(i-1)){
-          E_deaths[i,m] += prediction[j,m]*f[i-j,m];
-        }
-      }
-    }
-   /* for(m in 1:M) {
-     for(i in 1:N[m]) {
-      LowerBound[i,m] = prediction[i,m] * 10 - cases[i,m];
-     }
-    }*/
 
+    matrix[N2, M] prediction = rep_matrix(0, N2, M);
+    matrix[N2, M] E_deaths  = rep_matrix(0, N2, M);
+    matrix[N2, M] Rt = exp(covariate1 * (-alpha[1]) 
+                            + covariate2 * (-alpha[2]) 
+                            + covariate3 * (-alpha[3]) 
+                            + covariate4 * (-alpha[4]) 
+                            + covariate5 * (-alpha[5]) 
+                            + covariate6 * (-alpha[6])); // + GP[i]); // to_vector (x) * time_effect
+    for (m in 1:M) {
+        for (i in 1:N0) {
+            prediction[i, m] = y[m];
+        } // learn the number of cases in the first N0 days
+
+        Rt[, m] *= mu[m];
+        for (i in (N0 + 1):N2) {
+            real convolution = y[m] * sum(SI[1:(i - 1)]);
+            prediction[i, m] = Rt[i, m] * convolution;
+        }
+      
+        E_deaths = expected_deaths(prediction, f);
+    }
+    /* for(m in 1:M) {
+        for(i in 1:N[m]) {
+            LowerBound[i,m] = prediction[i,m] * 10 - cases[i,m];
+        }
+    }*/
 }
+
 model {
-  tau ~ exponential(0.03);
-  target += -sum(y_raw); // exponential(1) prior on y_raw implies y ~ exponential(1 / tau)
-  phi ~ normal(0,5);
-  kappa ~ normal(0,0.5);
-  mu ~ normal(2.4, kappa); // citation needed 
-  alpha ~ gamma(.5,1);
-  for(m in 1:M){
-    deaths[EpidemicStart[m]:N[m], m] ~ neg_binomial_2(E_deaths[EpidemicStart[m]:N[m], m], phi);
-  }
+    tau_unit ~ exponential(1); // implies tau ~ exponential(0.03)
+    target += -sum(y_raw); // exponential(1) prior on y_raw implies y ~ exponential(1 / tau)
+    phi ~ std_normal();
+    kappa ~ std_normal();
+    mu ~ normal(2.4, kappa); // citation needed 
+    alpha ~ gamma(0.5, 1);
+    for(m in 1:M) {
+        deaths[EpidemicStart[m]:N[m], m] ~ neg_binomial_2(
+            E_deaths[EpidemicStart[m]:N[m], m], 
+            phi
+        );
+    }
+}
+
+generated_data {
+    matrix[N2, M] matrix_1000 = rep_matrix(1000, N2, M);
+    matrix[N2, M] matrix_0 = rep_matrix(0, N2, M);
 }
 
 generated quantities {
-    matrix[N2, M] lp0 = rep_matrix(1000,N2,M); // log-probability for LOO for the counterfactual model
-    matrix[N2, M] lp1 = rep_matrix(1000,N2,M); // log-probability for LOO for the main model
-    matrix[N2, M] prediction0 = rep_matrix(0,N2,M);
-    matrix[N2, M] E_deaths0  = rep_matrix(0,N2,M);
-    for (m in 1:M){
-      prediction0[1:N0,m] = rep_vector(y[m],N0); // learn the number of cases in the first N0 days
-      for (i in (N0+1):N2) {
-        real convolution0=0;
-        for(j in 1:(i-1)) {
-          convolution0 += prediction0[j, m]*SI[i-j]; // Correctd 22nd March
-        }
-        prediction0[i, m] = mu[m] * convolution0;
-      }
+    matrix[N2, M] lp0 = matrix_1000; // log-probability for LOO for the counterfactual model
+    matrix[N2, M] lp1 = matrix_0; // log-probability for LOO for the main model
+    matrix[N2, M] prediction0 = rep_matrix(0, N2, M);
+    matrix[N2, M] E_deaths0  = rep_matrix(0, N2, M);
+    for (m in 1:M) {
+        prediction0[1:N0, m] = rep_vector(y[m], N0); // learn the number of cases in the first N0 days
+        for (i in (N0+1):N2) {
+            real convolution0 = 0;
+            for(j in 1:(i-1)) {
+                convolution0 += prediction0[j, m] * SI[i-j]; // Correctd 22nd March
+            }
+            prediction0[i, m] = mu[m] * convolution0;
+        } 
       
-      E_deaths0[1, m]= 1e-9;
-      for (i in 2:N2){
-        E_deaths0[i,m]= 0;
-        for(j in 1:(i-1)){
-          E_deaths0[i,m] += prediction0[j,m]*f[i-j,m];
-        }
-      }
-      for(i in 1:N[m]){
-        lp0[i,m] = neg_binomial_2_lpmf(deaths[i,m] | E_deaths[i,m],phi); 
-        lp1[i,m] = neg_binomial_2_lpmf(deaths[i,m] | E_deaths0[i,m],phi); 
-      }
-    }
+        E_deaths0 = expected_deaths(prediction0, f);
 
+        for(i in 1:N[m]) {
+            lp0[i, m] = neg_binomial_2_lpmf(deaths[i, m] | E_deaths[i, m], phi); 
+            lp1[i, m] = neg_binomial_2_lpmf(deaths[i, m] | E_deaths0[i, m], phi); 
+        }
+    }
 }
+
+functions {
+    matrix expected_deaths(matrix prediction, matrix f) {
+        int M = rows(prediction);
+        int N = cols(prediction);
+        matrix[M, N] y;
+        for (m in 1:M) {
+            y[1, m] = NaN;
+	        for (i in 2:M) {
+	            y[2, m] = 0;
+	            for (j in 1:(i - 1)) {
+	                y[i, m] += prediction[j, m] * f[i - j, m];
+                }
+            }
+        }
+        return y;
+    }
+  }


### PR DESCRIPTION
Implemented the code improvements suggested by Bob Carpenter in #33. 

**Problems**
- The function does not seem to work and throws the error
![Screenshot from 2020-04-07 23-44-14](https://user-images.githubusercontent.com/30379161/78726542-26841880-792a-11ea-8476-b277549a7d0e.png)

so I temporarily used the original loops as a placeholder (so that it works when tested on ubuntu and docker)

- Was thinking of converting the convolution routine into a function too, similar to the expected_deaths, as it is used twice
- I didn't quite get the suggestion
`
mu = 2.4 + kappa * mu_std;
`
why does the centred parameterisation work better?

- @flaxter @s-mishra is it okay to use `y_raw ~ exponential(1);  // implies y ~ exponential(1 / tau);` instead of `  target += -sum(y_raw);  // ...` as suggested? I don't think much speed will be sacrificed.

- More helpful comments should be used in the stan code.

Thanks again to Bob Carpenter for the helpful comments