### PR TITLE
Base.r that uses cmdstan with cmdstanr + optimized model

### DIFF
--- a/base_cmdstan.r
+++ b/base_cmdstan.r
@@ -1,7 +1,9 @@
 # install.packages("devtools")
 # devtools::install_github("jgabry/posterior")
-# install_github("stan-dev/cmdstanr")
+# devtools::install_github("stan-dev/cmdstanr")
 # cmdstanr::install_cmdstan(release_url = "https://github.com/stan-dev/cmdstan/releases/download/2.23-candidate/cmdstan-2.23-rc1.tar.gz", cores = 4)
+# install.packages(c("devtools", "data.table", "lubridate", "gdata", "dplyr", "tidyr", "EnvStats", "optparse", "rstan"))
+
 library(cmdstanr)
 library(data.table)
 library(lubridate)
@@ -232,7 +234,7 @@ if(DEBUG) {
 model <- cmdstan_model(paste0('stan-models/',StanModel,'.stan'), threads = TRUE)
 
 # this should probably be an option
-set_num_threads(4)
+set_num_threads(8)
 
 if(DEBUG) {
   cmdstanrfit = model$sample(data=stan_data,num_warmup = 20, num_samples = 20, num_chains = 2, num_cores = 2)
@@ -255,7 +257,7 @@ print(sprintf("Jobid = %s",JOBID))
 
 save.image(paste0('results/',StanModel,'-',JOBID,'.Rdata'))
 
-save(fittprediction,dates,reported_cases,deaths_by_country,countries,estimated.deaths,estimated.deaths.cf,out,covariates,file=paste0('results/',StanModel,'-',JOBID,'-stanfit.Rdata'))
+save(fit, prediction,dates,reported_cases,deaths_by_country,countries,estimated.deaths,estimated.deaths.cf,out,covariates,file=paste0('results/',StanModel,'-',JOBID,'-stanfit.Rdata'))
 
 library(bayesplot)
 filename <- paste0(StanModel,'-',JOBID)

--- a/base_cmdstan.r
+++ b/base_cmdstan.r
@@ -1,0 +1,280 @@
+# install.packages("devtools")
+# devtools::install_github("jgabry/posterior")
+# install_github("stan-dev/cmdstanr")
+# cmdstanr::install_cmdstan(release_url = "https://github.com/stan-dev/cmdstan/releases/download/2.23-candidate/cmdstan-2.23-rc1.tar.gz", cores = 4)
+library(cmdstanr)
+library(data.table)
+library(lubridate)
+library(gdata)
+library(dplyr)
+library(tidyr)
+library(EnvStats)
+library(optparse)
+
+countries <- c(
+  "Denmark",
+  "Italy",
+  "Germany",
+  "Spain",
+  "United_Kingdom",
+  "France",
+  "Norway",
+  "Belgium",
+  "Austria",
+  "Sweden",
+  "Switzerland",
+  "Greece",
+  "Portugal",
+  "Netherlands"
+)
+
+# Commandline options and parsing
+parser <- OptionParser()
+parser <- add_option(parser, c("-D", "--debug"), action="store_true",
+                     help="Perform a debug run of the model")
+parser <- add_option(parser, c("-F", "--full"), action="store_true",
+                     help="Perform a full run of the model")
+cmdoptions <- parse_args(parser, args = commandArgs(trailingOnly = TRUE), positional_arguments = TRUE)
+
+# Default run parameters for the model
+if(is.null(cmdoptions$options$debug)) {
+  DEBUG = Sys.getenv("DEBUG") == "TRUE"
+} else {
+  DEBUG = cmdoptions$options$debug
+}
+
+if(is.null(cmdoptions$options$full)) {
+  FULL = Sys.getenv("FULL") == "TRUE"
+} else {
+  FULL = cmdoptions$options$full
+}
+
+if(DEBUG && FULL) {
+  stop("Setting both debug and full run modes at once is invalid")
+}
+
+if(length(cmdoptions$args) == 0) {
+  StanModel = 'base_rs3'
+} else {
+  StanModel = cmdoptions$args[1]
+}
+
+print(sprintf("Running %s",StanModel))
+if(DEBUG) {
+  print("Running in DEBUG mode")
+} else if (FULL) {
+  print("Running in FULL mode")
+}
+
+## Reading all data
+d=readRDS('data/COVID-19-up-to-date.rds')
+
+## Ensure that output directories exist
+dir.create("results/", showWarnings = FALSE, recursive = TRUE)
+dir.create("figures/", showWarnings = FALSE, recursive = TRUE)
+dir.create("web/", showWarnings = FALSE, recursive = TRUE)
+
+## get IFR and population from same file
+ifr.by.country = read.csv("data/popt_ifr.csv")
+ifr.by.country$country = as.character(ifr.by.country[,2])
+ifr.by.country$country[ifr.by.country$country == "United Kingdom"] = "United_Kingdom"
+
+serial.interval = read.csv("data/serial_interval.csv")
+covariates = read.csv('data/interventions.csv', stringsAsFactors = FALSE)
+names_covariates = c('Schools + Universities','Self-isolating if ill', 'Public events', 'Lockdown', 'Social distancing encouraged')
+covariates <- covariates %>%
+  filter((Type %in% names_covariates))
+covariates <- covariates[,c(1,2,4)]
+covariates <- spread(covariates, Type, Date.effective)
+names(covariates) <- c('Country','lockdown', 'public_events', 'schools_universities','self_isolating_if_ill', 'social_distancing_encouraged')
+covariates <- covariates[c('Country','schools_universities', 'self_isolating_if_ill', 'public_events', 'lockdown', 'social_distancing_encouraged')]
+covariates$schools_universities <- as.Date(covariates$schools_universities, format = "%d.%m.%Y")
+covariates$lockdown <- as.Date(covariates$lockdown, format = "%d.%m.%Y")
+covariates$public_events <- as.Date(covariates$public_events, format = "%d.%m.%Y")
+covariates$self_isolating_if_ill <- as.Date(covariates$self_isolating_if_ill, format = "%d.%m.%Y")
+covariates$social_distancing_encouraged <- as.Date(covariates$social_distancing_encouraged, format = "%d.%m.%Y")
+## using covariates as dates we want
+covariates$schools_universities[covariates$schools_universities > covariates$lockdown] <- covariates$lockdown[covariates$schools_universities > covariates$lockdown]
+covariates$public_events[covariates$public_events > covariates$lockdown] <- covariates$lockdown[covariates$public_events > covariates$lockdown]
+covariates$social_distancing_encouraged[covariates$social_distancing_encouraged > covariates$lockdown] <- covariates$lockdown[covariates$social_distancing_encouraged > covariates$lockdown]
+covariates$self_isolating_if_ill[covariates$self_isolating_if_ill > covariates$lockdown] <- covariates$lockdown[covariates$self_isolating_if_ill > covariates$lockdown]
+
+forecast = 0
+
+N2 = 90 # increase if you need more forecast
+
+dates = list()
+reported_cases = list()
+stan_data = list(M=length(countries),N=NULL,covariate1=NULL,covariate2=NULL,covariate3=NULL,covariate4=NULL,covariate5=NULL,covariate6=NULL,deaths=NULL,f=NULL,
+                 N0=6,cases=NULL,SI=serial.interval$fit[1:N2],
+                 EpidemicStart = NULL, pop = NULL) # N0 = 6 to make it consistent with Rayleigh
+deaths_by_country = list()
+
+# various distributions required for modeling
+mean1 = 5.1; cv1 = 0.86; # infection to onset
+mean2 = 18.8; cv2 = 0.45 # onset to death
+x1 = rgammaAlt(1e7,mean1,cv1) # infection-to-onset distribution
+x2 = rgammaAlt(1e7,mean2,cv2) # onset-to-death distribution
+
+ecdf.saved = ecdf(x1+x2)
+
+for(Country in countries) {
+  IFR=ifr.by.country$ifr[ifr.by.country$country == Country]
+
+  covariates1 <- covariates[covariates$Country == Country, c(2,3,4,5,6)]
+
+  d1_pop = ifr.by.country[ifr.by.country$country==Country,]
+  d1=d[d$Countries.and.territories==Country,c(1,5,6,7)]
+  d1$date = as.Date(d1$DateRep,format='%d/%m/%Y')
+  d1$t = decimal_date(d1$date)
+  d1=d1[order(d1$t),]
+
+  date_min <- dmy('31/12/2019')
+  if (as.Date(d1$DateRep[1], format='%d/%m/%Y') > as.Date(date_min, format='%d/%m/%Y')){
+    print(paste(Country,'In padding'))
+    pad_days <- as.Date(d1$DateRep[1], format='%d/%m/%Y') - date_min
+    pad_dates <- date_min + days(1:pad_days[[1]]-1)
+    padded_data <- data.frame("Countries.and.territories" = rep(Country, pad_days),
+                              "DateRep" = format(pad_dates, '%d/%m/%Y'),
+                              "t" = decimal_date(as.Date(pad_dates,format='%d/%m/%Y')),
+                              "date" = as.Date(pad_dates,format='%d/%m/%Y'),
+                              "Cases" = as.integer(rep(0, pad_days)),
+                              "Deaths" = as.integer(rep(0, pad_days)),
+                              stringsAsFactors=F)
+
+    d1 <- bind_rows(padded_data, d1)
+  }
+  index = which(d1$Cases>0)[1]
+  index1 = which(cumsum(d1$Deaths)>=10)[1] # also 5
+  index2 = index1-30
+
+  print(sprintf("First non-zero cases is on day %d, and 30 days before 10 deaths is day %d",index,index2))
+  d1=d1[index2:nrow(d1),]
+  stan_data$EpidemicStart = c(stan_data$EpidemicStart,index1+1-index2)
+  stan_data$pop = c(stan_data$pop, d1_pop$popt)
+
+
+  for (ii in 1:ncol(covariates1)) {
+    covariate = names(covariates1)[ii]
+    d1[covariate] <- (as.Date(d1$DateRep, format='%d/%m/%Y') >= as.Date(covariates1[1,covariate]))*1  # should this be > or >=?
+  }
+
+  dates[[Country]] = d1$date
+  # hazard estimation
+  N = length(d1$Cases)
+  print(sprintf("%s has %d days of data",Country,N))
+  forecast = N2 - N
+  if(forecast < 0) {
+    print(sprintf("%s: %d", Country, N))
+    print("ERROR!!!! increasing N2")
+    N2 = N
+    forecast = N2 - N
+  }
+
+  # IFR is the overall probability of dying given infection
+  convolution = function(u) (IFR * ecdf.saved(u))
+
+  f = rep(0,N2) # f is the probability of dying on day i given infection
+  f[1] = (convolution(1.5) - convolution(0))
+  for(i in 2:N2) {
+    f[i] = (convolution(i+.5) - convolution(i-.5))
+  }
+
+  reported_cases[[Country]] = as.vector(as.numeric(d1$Cases))
+  deaths=c(as.vector(as.numeric(d1$Deaths)),rep(-1,forecast))
+  cases=c(as.vector(as.numeric(d1$Cases)),rep(-1,forecast))
+  deaths_by_country[[Country]] = as.vector(as.numeric(d1$Deaths))
+  covariates2 <- as.data.frame(d1[, colnames(covariates1)])
+  # x=1:(N+forecast)
+  covariates2[N:(N+forecast),] <- covariates2[N,]
+
+  ## append data
+  stan_data$N = c(stan_data$N,N)
+  # stan_data$x = cbind(stan_data$x,x)
+  stan_data$covariate1 = cbind(stan_data$covariate1,covariates2[,1])
+  stan_data$covariate2 = cbind(stan_data$covariate2,covariates2[,2])
+  stan_data$covariate3 = cbind(stan_data$covariate3,covariates2[,3])
+  stan_data$covariate4 = cbind(stan_data$covariate4,covariates2[,4])
+  stan_data$covariate5 = cbind(stan_data$covariate5,covariates2[,4])
+  stan_data$covariate6 = cbind(stan_data$covariate6,covariates2[,5])
+  stan_data$f = cbind(stan_data$f,f)
+  stan_data$deaths = cbind(stan_data$deaths,deaths)
+  stan_data$cases = cbind(stan_data$cases,cases)
+
+  stan_data$N2=N2
+  stan_data$x=1:N2
+  if(length(stan_data$N) == 1) {
+    stan_data$N = as.array(stan_data$N)
+  }
+}
+
+# create the `any intervention` covariate
+stan_data$covariate4 = 1*as.data.frame((stan_data$covariate1+
+                                          stan_data$covariate2+
+                                          stan_data$covariate3+
+                                          stan_data$covariate5+
+                                          stan_data$covariate6) >= 1)
+
+if(DEBUG) {
+  for(i in 1:length(countries)) {
+    write.csv(
+      data.frame(date=dates[[i]],
+                 `school closure`=stan_data$covariate1[1:stan_data$N[i],i],
+                 `self isolating if ill`=stan_data$covariate2[1:stan_data$N[i],i],
+                 `public events`=stan_data$covariate3[1:stan_data$N[i],i],
+                 `government makes any intervention`=stan_data$covariate4[1:stan_data$N[i],i],
+                 `lockdown`=stan_data$covariate5[1:stan_data$N[i],i],
+                 `social distancing encouraged`=stan_data$covariate6[1:stan_data$N[i],i]),
+      file=sprintf("results/%s-check-dates.csv",countries[i]),row.names=F)
+  }
+}
+
+model <- cmdstan_model(paste0('stan-models/',StanModel,'.stan'), threads = TRUE)
+
+# this should probably be an option
+set_num_threads(4)
+
+if(DEBUG) {
+  cmdstanrfit = model$sample(data=stan_data,num_warmup = 20, num_samples = 20, num_chains = 2, num_cores = 2)
+} else if (FULL) {
+  cmdstanrfit = model$sample(data=stan_data, num_warmup=2000, num_samples=2000, num_chains=4, num_cores = 4, thin=4, max_depth = 10, adapt_delta = 0.95)
+} else {
+  cmdstanrfit = model$sample(data=stan_data,num_warmup=100,num_samples=100,chains=4, thin=4, adapt_delta = 0.95, max_depth = 10)
+}
+
+fit <- rstan::read_stan_csv(cmdstanrfit$output_files())
+out = rstan::extract(fit)
+prediction = out$prediction
+estimated.deaths = out$E_deaths
+estimated.deaths.cf = out$E_deaths0
+
+JOBID = Sys.getenv("PBS_JOBID")
+if(JOBID == "")
+  JOBID = as.character(abs(round(rnorm(1) * 1000000)))
+print(sprintf("Jobid = %s",JOBID))
+
+save.image(paste0('results/',StanModel,'-',JOBID,'.Rdata'))
+
+save(fittprediction,dates,reported_cases,deaths_by_country,countries,estimated.deaths,estimated.deaths.cf,out,covariates,file=paste0('results/',StanModel,'-',JOBID,'-stanfit.Rdata'))
+
+library(bayesplot)
+filename <- paste0(StanModel,'-',JOBID)
+system(paste0("Rscript covariate-size-effects.r ", filename,'-stanfit.Rdata'))
+mu = (as.matrix(out$mu))
+colnames(mu) = countries
+g = (mcmc_intervals(mu,prob = .9))
+ggsave(sprintf("results/%s-mu.png",filename),g,width=4,height=6)
+tmp = lapply(1:length(countries), function(i) (out$Rt_adj[,stan_data$N[i],i]))
+Rt_adj = do.call(cbind,tmp)
+colnames(Rt_adj) = countries
+g = (mcmc_intervals(Rt_adj,prob = .9))
+ggsave(sprintf("results/%s-final-rt.png",filename),g,width=4,height=6)
+system(paste0("Rscript plot-3-panel.r ", filename,'-stanfit.Rdata'))
+system(paste0("Rscript plot-forecast.r ",filename,'-stanfit.Rdata'))
+system(paste0("Rscript make-table.r results/",filename,'-stanfit.Rdata'))
+verify_result <- system(paste0("Rscript web-verify-output.r ", filename,'.Rdata'),intern=FALSE)
+if(verify_result != 0){
+  stop("Verification of web output failed!")
+}
+
+

--- a/stan-models/base_rs2.stan
+++ b/stan-models/base_rs2.stan
@@ -1,0 +1,188 @@
+functions {
+  // this is the partial sum function which calculates for
+  // a subset of countries the log-lik contribution
+  // so it computes for the countries m= start...end the
+  // log lik
+  // note: in the 2.23 release candidate the partial sum function has
+  // this signature below, but that is changed to
+  //real country_log_lik(real[] mu_slice,
+  //                     int start, int end,
+  // in the final 2.23... so adapt it next week                     
+  real country_log_lik(int start, int end,
+                       real[] mu_slice,
+                       real[] alpha,
+                       real[] y,
+                       real ophi,
+                       real[] ifr_noise,
+                       int[] N,
+                       int N0,
+                       int N2,
+                       matrix covariate1,
+                       matrix covariate2,
+                       matrix covariate3,
+                       matrix covariate4,
+                       matrix covariate5,
+                       matrix covariate6,
+                       real[] SI,
+                       real[] pop,
+                       matrix f,
+                       int[,] deaths,
+                       int[] EpidemicStart
+                       ) {
+    // log-lik of this subset
+    real log_lik = 0.0;
+    // number of countries
+    int M_slice = end - start + 1;
+    // terms of this country subset
+    matrix[N2, M_slice] prediction = rep_matrix(0,N2,M_slice);
+    matrix[N2, M_slice] E_deaths  = rep_matrix(0,N2,M_slice);
+    matrix[N2, M_slice] Rt = rep_matrix(0,N2,M_slice);
+    matrix[N2, M_slice] Rt_adj = Rt;
+    matrix[N2,M_slice] cumm_sum = rep_matrix(0,N2,M_slice);
+
+    // the index m runs with the actual index of each country in the
+    // original data set while m_slice is offset such that it runs
+    // from 1...M_slice (so a consecutive indexing of the subset
+    // starting from 1).
+    
+    for (m in start:end) {
+      int m_slice = m - start + 1;
+      for (i in 2:N0){
+        cumm_sum[i,m_slice] = cumm_sum[i-1,m_slice] + y[m]; 
+      }
+      prediction[1:N0,m_slice] = rep_vector(y[m], N0); // learn the number of cases in the first N0 days
+       
+      Rt[,m_slice] = mu_slice[m_slice] * exp( covariate1[,m] * (-alpha[1]) + covariate2[,m] * (-alpha[2]) +
+                                              covariate3[,m] * (-alpha[3]) + covariate4[,m] * (-alpha[4]) + covariate5[,m] * (-alpha[5]) + 
+                                              covariate6[,m] * (-alpha[6]) );
+      Rt_adj[1:N0,m_slice] = Rt[1:N0,m_slice];
+      
+      for (i in (N0+1):N2) {
+        real convolution=0;
+        for(j in 1:(i-1)) {
+          convolution += prediction[j, m_slice] * SI[i-j];
+        }
+        cumm_sum[i,m_slice] = cumm_sum[i-1,m_slice] + prediction[i-1,m_slice];
+        Rt_adj[i,m_slice] = ((pop[m]-cumm_sum[i,m_slice]) / pop[m]) * Rt[i,m_slice];
+        prediction[i, m_slice] = Rt_adj[i,m_slice] * convolution;
+      }
+        
+      E_deaths[1, m_slice]= 1e-15 * prediction[1,m_slice];
+      for (i in 2:N2){
+        for(j in 1:(i-1)){
+          E_deaths[i,m_slice] += prediction[j,m_slice] * f[i-j,m] * ifr_noise[m];
+        }
+      }
+    }
+
+    for(m in start:end) {
+      int m_slice = m - start + 1;
+      log_lik += neg_binomial_2_lpmf(deaths[EpidemicStart[m]:N[m], m]| E_deaths[EpidemicStart[m]:N[m], m_slice], ophi );
+    }
+    
+    return(log_lik);
+  }
+}
+data {
+  int <lower=1> M; // number of countries
+  int <lower=1> N0; // number of days for which to impute infections
+  int<lower=1> N[M]; // days of observed data for country m. each entry must be <= N2
+  int<lower=1> N2; // days of observed data + # of days to forecast
+  int cases[N2,M]; // reported cases
+  int deaths[N2, M]; // reported deaths -- the rows with i > N contain -1 and should be ignored
+  matrix[N2, M] f; // h * s
+  matrix[N2, M] covariate1;
+  matrix[N2, M] covariate2;
+  matrix[N2, M] covariate3;
+  matrix[N2, M] covariate4;
+  matrix[N2, M] covariate5;
+  matrix[N2, M] covariate6;
+  int EpidemicStart[M];
+  real pop[M];
+  real SI[N2]; // fixed pre-calculated SI using emprical data from Neil
+}
+
+parameters {
+  real<lower=0> mu[M]; // intercept for Rt
+  real<lower=0> alpha_hier[6]; // sudo parameter for the hier term for alpha
+  real<lower=0> kappa;
+  real<lower=0> y[M];
+  real<lower=0> ophi;
+  real<lower=0> tau;
+  real<lower=0> ifr_noise[M];
+}
+
+transformed parameters {
+  real alpha[6];
+
+  for(i in 1:6){
+    alpha[i] = alpha_hier[i] - ( log(1.05) / 6.0 );
+  }
+    
+}
+model {
+  tau ~ exponential(0.03);
+  for (m in 1:M){
+      y[m] ~ exponential(1/tau);
+  }
+  ophi ~ normal(0,5);
+  kappa ~ normal(0,0.5);
+  mu ~ normal(3.28, kappa); // citation: https://academic.oup.com/jtm/article/27/2/taaa021/5735319
+  alpha_hier ~ gamma(.1667,1);
+  ifr_noise ~ normal(1,0.1);
+  /*
+  for(m in 1:M){
+    deaths[EpidemicStart[m]:N[m], m] ~ neg_binomial_2(E_deaths[EpidemicStart[m]:N[m], m], phi);
+   }
+  */
+  target += reduce_sum(country_log_lik, mu, 1,
+                       alpha,
+                       y,
+                       ophi,
+                       ifr_noise,
+                       N,
+                       N0,
+                       N2,
+                       covariate1,
+                       covariate2,
+                       covariate3,
+                       covariate4,
+                       covariate5,
+                       covariate6,
+                       SI,
+                       pop,
+                       f,
+                       deaths,
+                       EpidemicStart
+                       );
+}
+generated quantities {
+    matrix[N2, M] prediction0 = rep_matrix(0,N2,M);
+    matrix[N2, M] E_deaths0  = rep_matrix(0,N2,M);
+    
+    {
+      matrix[N2,M] cumm_sum0 = rep_matrix(0,N2,M);
+      for (m in 1:M){
+         for (i in 2:N0){
+          cumm_sum0[i,m] = cumm_sum0[i-1,m] + y[m]; 
+        }
+        prediction0[1:N0,m] = rep_vector(y[m],N0); 
+        for (i in (N0+1):N2) {
+          real convolution0 = 0;
+          for(j in 1:(i-1)) {
+            convolution0 += prediction0[j, m] * SI[i-j]; 
+          }
+          cumm_sum0[i,m] = cumm_sum0[i-1,m] + prediction0[i-1,m];
+          prediction0[i, m] =  ((pop[m]-cumm_sum0[i,m]) / pop[m]) * mu[m] * convolution0;
+        }
+        
+        E_deaths0[1, m] = uniform_rng(1e-16, 1e-15);
+        for (i in 2:N2){
+          for(j in 1:(i-1)){
+            E_deaths0[i,m] += prediction0[j,m] * f[i-j,m] * ifr_noise[m];
+          }
+        }
+      }
+    }
+}
+

--- a/stan-models/base_rs3.stan
+++ b/stan-models/base_rs3.stan
@@ -1,0 +1,234 @@
+functions {
+  // this is the partial sum function which calculates for
+  // a subset of countries the log-lik contribution
+  // so it computes for the countries m= start...end the
+  // log lik
+  // note: in the 2.23 release candidate the partial sum function has
+  // this signature below, but that is changed to
+  //real country_log_lik(real[] mu_slice,
+  //                     int start, int end,
+  // in the final 2.23... so adapt it next week
+  real country_log_lik(int start, int end,
+                       real[] mu_slice,
+                       vector alpha,
+                       real[] y,
+                       real ophi,
+                       real[] ifr_noise,
+                       int[] N,
+                       int N0,
+                       int N2,
+                       /*
+                       matrix covariate1,
+                       matrix covariate2,
+                       matrix covariate3,
+                       matrix covariate4,
+                       matrix covariate5,
+                       matrix covariate6,
+                       */
+                       matrix[] X,
+                       vector SI_rev,
+                       real[] pop,
+                       vector[] f_rev,
+                       int[,] deaths,
+                       int[] EpidemicStart
+                       ) {
+    // log-lik of this subset
+    real log_lik = 0.0;
+    // number of countries
+    int M_slice = end - start + 1;
+    // terms of this country subset
+    matrix[N2, M_slice] prediction = rep_matrix(0,N2,M_slice);
+    matrix[N2, M_slice] E_deaths  = rep_matrix(0,N2,M_slice);
+    matrix[N2, M_slice] Rt = rep_matrix(0,N2,M_slice);
+    matrix[N2, M_slice] Rt_adj = Rt;
+    matrix[N2,M_slice] cumm_sum = rep_matrix(0,N2,M_slice);
+
+    // the index m runs with the actual index of each country in the
+    // original data set while m_slice is offset such that it runs
+    // from 1...M_slice (so a consecutive indexing of the subset
+    // starting from 1).
+
+    for (m in start:end) {
+      int m_slice = m - start + 1;
+      //for (i in 2:N0){
+      //  cumm_sum[i,m_slice] = cumm_sum[i-1,m_slice] + y[m];
+      //}
+      prediction[1:N0,m_slice] = rep_vector(y[m], N0); // learn the
+                                                       // number of
+                                                       // cases in the
+                                                       // first N0
+                                                       // days
+      cumm_sum[2:N0,m_slice] = cumulative_sum(prediction[2:N0,m_slice]);
+
+      /*
+      Rt[,m_slice] = mu_slice[m_slice] * exp( covariate1[,m] * (-alpha[1]) + covariate2[,m] * (-alpha[2]) +
+                                              covariate3[,m] * (-alpha[3]) + covariate4[,m] * (-alpha[4]) + covariate5[,m] * (-alpha[5]) +
+                                              covariate6[,m] * (-alpha[6]) );
+      */
+
+      Rt[,m_slice] = mu_slice[m_slice] * exp( - X[m] * alpha );
+      Rt_adj[1:N0,m_slice] = Rt[1:N0,m_slice];
+
+      for (i in (N0+1):N2) {
+        /*
+        real convolution=0;
+        for(j in 1:(i-1)) {
+          convolution += prediction[j, m_slice] * SI[i-j];
+        }
+        */
+        real convolution = dot_product(sub_col(prediction, 1, m_slice, i-1), tail(SI_rev, i-1));
+
+        cumm_sum[i,m_slice] = cumm_sum[i-1,m_slice] + prediction[i-1,m_slice];
+        Rt_adj[i,m_slice] = ((pop[m]-cumm_sum[i,m_slice]) / pop[m]) * Rt[i,m_slice];
+        prediction[i, m_slice] = Rt_adj[i,m_slice] * convolution;
+      }
+
+      /*
+      E_deaths[1, m_slice]= 1e-15 * prediction[1,m_slice];
+      for (i in 2:N2){
+        for(j in 1:(i-1)){
+          E_deaths[i,m_slice] += prediction[j,m_slice] * f[i-j,m] * ifr_noise[m];
+        }
+      }
+      */
+      E_deaths[1, m_slice]= 1e-15 * prediction[1,m_slice];
+      for (i in 2:N2) {
+        E_deaths[i,m_slice] = ifr_noise[m] * dot_product(sub_col(prediction, 1, m_slice, i), tail(f_rev[m], i));
+        //for(j in 1:(i-1)){
+        //  E_deaths[i,m_slice] += prediction[j,m_slice] * f[i-j,m] * ifr_noise[m];
+        //}
+      }
+    }
+
+    for(m in start:end) {
+      int m_slice = m - start + 1;
+      log_lik += neg_binomial_2_lpmf(deaths[EpidemicStart[m]:N[m], m]| E_deaths[EpidemicStart[m]:N[m], m_slice], ophi );
+    }
+
+    return(log_lik);
+  }
+}
+data {
+  int <lower=1> M; // number of countries
+  int <lower=1> N0; // number of days for which to impute infections
+  int<lower=1> N[M]; // days of observed data for country m. each entry must be <= N2
+  int<lower=1> N2; // days of observed data + # of days to forecast
+  int cases[N2,M]; // reported cases
+  int deaths[N2, M]; // reported deaths -- the rows with i > N contain -1 and should be ignored
+  matrix[N2, M] f; // h * s
+  matrix[N2, M] covariate1;
+  matrix[N2, M] covariate2;
+  matrix[N2, M] covariate3;
+  matrix[N2, M] covariate4;
+  matrix[N2, M] covariate5;
+  matrix[N2, M] covariate6;
+  int EpidemicStart[M];
+  real pop[M];
+  real SI[N2]; // fixed pre-calculated SI using emprical data from Neil
+}
+transformed data {
+  vector[N2] f_rev[M]; // reversed order
+  matrix[N2, 6] X[M];    // design matrix per country
+  vector[N2] SI_rev;
+  for(m in 1:M) {
+    for(i in 1:N2) {
+      f_rev[m,i] = f[N2-i+1,m];
+    }
+
+    X[m,:,1] = covariate1[:,m];
+    X[m,:,2] = covariate2[:,m];
+    X[m,:,3] = covariate3[:,m];
+    X[m,:,4] = covariate4[:,m];
+    X[m,:,5] = covariate5[:,m];
+    X[m,:,6] = covariate6[:,m];
+  }
+
+  for(i in 1:N2)
+    SI_rev[i] = SI[N2-i+1];
+}
+
+parameters {
+  real<lower=0> mu[M]; // intercept for Rt
+  real<lower=0> alpha_hier[6]; // sudo parameter for the hier term for alpha
+  real<lower=0> kappa;
+  real<lower=0> y[M];
+  real<lower=0> ophi;
+  real<lower=0> tau;
+  real<lower=0> ifr_noise[M];
+}
+
+transformed parameters {
+  vector[6] alpha;
+
+  for(i in 1:6){
+    alpha[i] = alpha_hier[i] - ( log(1.05) / 6.0 );
+  }
+}
+model {
+  tau ~ exponential(0.03);
+  for (m in 1:M){
+      y[m] ~ exponential(1/tau);
+  }
+  ophi ~ normal(0,5);
+  kappa ~ normal(0,0.5);
+  mu ~ normal(3.28, kappa); // citation: https://academic.oup.com/jtm/article/27/2/taaa021/5735319
+  alpha_hier ~ gamma(.1667,1);
+  ifr_noise ~ normal(1,0.1);
+  /*
+  for(m in 1:M){
+    deaths[EpidemicStart[m]:N[m], m] ~ neg_binomial_2(E_deaths[EpidemicStart[m]:N[m], m], phi);
+   }
+  */
+  target += reduce_sum(country_log_lik, mu, 1,
+                       alpha,
+                       y,
+                       ophi,
+                       ifr_noise,
+                       N,
+                       N0,
+                       N2,
+                       /*
+                       covariate1,
+                       covariate2,
+                       covariate3,
+                       covariate4,
+                       covariate5,
+                       covariate6,
+                       */
+                       X,
+                       SI_rev,
+                       pop,
+                       f_rev,
+                       deaths,
+                       EpidemicStart
+                       );
+}
+generated quantities {
+    matrix[N2, M] prediction0 = rep_matrix(0,N2,M);
+    matrix[N2, M] E_deaths0  = rep_matrix(0,N2,M);
+
+    {
+      matrix[N2,M] cumm_sum0 = rep_matrix(0,N2,M);
+      for (m in 1:M){
+         for (i in 2:N0){
+          cumm_sum0[i,m] = cumm_sum0[i-1,m] + y[m];
+        }
+        prediction0[1:N0,m] = rep_vector(y[m],N0);
+        for (i in (N0+1):N2) {
+          real convolution0 = 0;
+          for(j in 1:(i-1)) {
+            convolution0 += prediction0[j, m] * SI[i-j];
+          }
+          cumm_sum0[i,m] = cumm_sum0[i-1,m] + prediction0[i-1,m];
+          prediction0[i, m] =  ((pop[m]-cumm_sum0[i,m]) / pop[m]) * mu[m] * convolution0;
+        }
+
+        E_deaths0[1, m] = uniform_rng(1e-16, 1e-15);
+        for (i in 2:N2){
+          for(j in 1:(i-1)){
+            E_deaths0[i,m] += prediction0[j,m] * f[i-j,m] * ifr_noise[m];
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
This adds another version of base that uses cmdstan (via cmdstanr).
The change compared to the use of rstan is minimal (the output is an rstan fit object).

It also adds the model @wds15 optimized.

At the top of the script is the installation instruction.

Install required packages:
```
install.packages("devtools")
devtools::install_github("jgabry/posterior")
devtools::install_github("stan-dev/cmdstanr")
```
And cmdstan 2.23 release candidate:
```
`cmdstanr::install_cmdstan(release_url = "https://github.com/stan-dev/cmdstan/releases/download/2.23-candidate/cmdstan-2.23-rc1.tar.gz", cores = 4)
```