### PR TITLE
Allow forecasting beyond the 100 days enabled by serial_interval.csv

### DIFF
--- a/base.r
+++ b/base.r
@@ -97,7 +97,7 @@ covariates$self_isolating_if_ill[covariates$self_isolating_if_ill > covariates$l
 
 forecast = 0
 
-N2 = 90 # increase if you need more forecast
+N2 = 120 # increase if you need more forecast
 
 dates = list()
 reported_cases = list()

--- a/base.r
+++ b/base.r
@@ -101,6 +101,15 @@ N2 = 120 # increase if you need more forecast
 
 dates = list()
 reported_cases = list()
+# Pads serial interval with 0 if N2 is greater than the length of the serial
+# interval array
+if (N2 > length(serial.interval$fit)) {
+  pad_serial.interval <- data.frame(
+    "X"=(length(serial.interval$fit)+1):N2,
+    "fit"=rep(0.0, max(N2-length(serial.interval$fit), 0 ))
+  )
+  serial.interval = rbind(serial.interval, pad_serial.interval)
+}
 stan_data = list(M=length(countries),N=NULL,covariate1=NULL,covariate2=NULL,covariate3=NULL,covariate4=NULL,covariate5=NULL,covariate6=NULL,deaths=NULL,f=NULL,
                  N0=6,cases=NULL,SI=serial.interval$fit[1:N2],
                  EpidemicStart = NULL, pop = NULL) # N0 = 6 to make it consistent with Rayleigh


### PR DESCRIPTION
Issue #77 outlines a problem arising from the length of the epidemic as we are
reaching the 90 days modelling window for Italy.

This proposes a long term fix by padding serial interval data with 0s and increasing
the value of N2. 