### PR TITLE
Increase N2, improved error handling, CI workflow downloads ECDC data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
       run: |
         docker build -f docker/Dockerfile -t covid19model:latest .
 
-    - name: Perform a short debug simulation run
+    - name: Perform a short debug simulation run incl. fetching from the ECDC
       run: |
-        docker run --rm --user $(id -u):$(id -g) --env DEBUG=TRUE covid19model:latest 
+        docker run --rm --user $(id -u):$(id -g) --env DEBUG=TRUE covid19model:latest Rscript web-fetch-and-run.r
 
     - name: Push image to GitHub packages
       if: github.event_name == 'push'

--- a/base.r
+++ b/base.r
@@ -97,7 +97,7 @@ covariates$self_isolating_if_ill[covariates$self_isolating_if_ill > covariates$l
 
 forecast = 0
 
-N2 = 90 # increase if you need more forecast
+N2 = 99 # increase if you need more forecast
 
 dates = list()
 reported_cases = list()

--- a/base.r
+++ b/base.r
@@ -254,7 +254,13 @@ save(fit,prediction,dates,reported_cases,deaths_by_country,countries,estimated.d
 
 library(bayesplot)
 filename <- paste0(StanModel,'-',JOBID)
-system(paste0("Rscript covariate-size-effects.r ", filename,'-stanfit.Rdata'))
+
+print("Generating covariate size effects plot")
+covariate_size_effects_error <- system(paste0("Rscript covariate-size-effects.r ", filename,'-stanfit.Rdata'),intern=FALSE)
+if(covariate_size_effects_error != 0){
+  stop(sprintf("Error while plotting covariate size effects! Code: %d", covariate_size_effects_error))
+}
+
 mu = (as.matrix(out$mu))
 colnames(mu) = countries
 g = (mcmc_intervals(mu,prob = .9))
@@ -264,10 +270,26 @@ Rt_adj = do.call(cbind,tmp)
 colnames(Rt_adj) = countries
 g = (mcmc_intervals(Rt_adj,prob = .9))
 ggsave(sprintf("results/%s-final-rt.png",filename),g,width=4,height=6)
-system(paste0("Rscript plot-3-panel.r ", filename,'-stanfit.Rdata'))
-system(paste0("Rscript plot-forecast.r ",filename,'-stanfit.Rdata'))
-system(paste0("Rscript make-table.r results/",filename,'-stanfit.Rdata'))
-verify_result <- system(paste0("Rscript web-verify-output.r ", filename,'.Rdata'),intern=FALSE)
-if(verify_result != 0){
-  stop("Verification of web output failed!")
+
+print("Generate 3-panel plots")
+plot_3_panel_error <- system(paste0("Rscript plot-3-panel.r ", filename,'-stanfit.Rdata'),intern=FALSE)
+if(plot_3_panel_error != 0){
+  stop(sprintf("Generation of 3-panel plots failed! Code: %d", plot_3_panel_error))
+}
+
+print("Generate forecast plot")
+plot_forecast_error <- system(paste0("Rscript plot-forecast.r ",filename,'-stanfit.Rdata'),intern=FALSE)
+if(plot_forecast_error != 0) {
+  stop(sprintf("Generation of forecast plot failed! Code: %d", plot_forecast_error))
+}
+
+print("Make forecast table")
+make_table_error <- system(paste0("Rscript make-table.r results/",filename,'-stanfit.Rdata'),intern=FALSE)
+if(make_table_error != 0){
+  stop(sprintf("Generation of alpha covar table failed! Code: %d", make_table_error))
+}
+
+verify_result_error <- system(paste0("Rscript web-verify-output.r ", filename,'.Rdata'),intern=FALSE)
+if(verify_result_error != 0){
+  stop(sprintf("Verification of web output failed! Code: %d", verify_result_error))
 }

--- a/data/fetch-ecdc.r
+++ b/data/fetch-ecdc.r
@@ -10,8 +10,8 @@ url <- "https://opendata.ecdc.europa.eu/covid19/casedistribution/csv"
 url_page <- "https://www.ecdc.europa.eu/en/publications-data/download-todays-data-geographic-distribution-covid-19-cases-worldwide"
 tryCatch({
   #download the dataset from the ECDC website to a local temporary file
-  r <- GET("https://opendata.ecdc.europa.eu/covid19/casedistribution/csv", 
-           authenticate(":", ":", type="ntlm"), write_disk("data/COVID-19-up-to-date.csv", overwrite=TRUE))
+  r <- RETRY("GET", "https://opendata.ecdc.europa.eu/covid19/casedistribution/csv", 
+             write_disk("data/COVID-19-up-to-date.csv", overwrite=TRUE))
   
   if (http_error(r)) {
     stop("Error downloading file")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,6 @@ RUN mkdir results
 RUN mkdir figures
 RUN mkdir web
 RUN touch Rplots.pdf
-RUN chmod -R a+rwx results figures web Rplots.pdf
+RUN chmod -R a+rwx data results figures web Rplots.pdf
 
 CMD Rscript base.r base

--- a/web-fetch-and-run.r
+++ b/web-fetch-and-run.r
@@ -1,2 +1,10 @@
-system("Rscript data/fetch-ecdc.r")
-system("Rscript base.r base")
+print("Fetching data from ECDC")
+fetch_ecdc_error <- system("Rscript data/fetch-ecdc.r",intern=FALSE)
+if(fetch_ecdc_error != 0){
+  stop(sprintf("Error while fetching data from the ECDC! Code: %d", fetch_ecdc_error))
+}
+
+run_base_error <- system("Rscript base.r base",intern=FALSE)
+if(run_base_error != 0){
+  stop(sprintf("Error while running base.r! Code: %d", run_base_error))
+}

--- a/web-verify-output.r
+++ b/web-verify-output.r
@@ -19,8 +19,9 @@ countries <- c(
 
 web_fix_fonts <- function(path){
   x <- readLines(path)
-  y <- gsub( "Aerial", "Arial, Helvetica, sans-serif", x )
-  y <- gsub( "Arimo", "Arial, Helvetica, sans-serif", y )
+  y <- gsub("Aerial", "Arial, Helvetica, sans-serif",x)
+  y <- gsub("Arimo", "Arial, Helvetica, sans-serif",y)
+  y <- gsub("DejaVu Sans", "Arial, Helvetica, sans-serif", y)
   cat(y, file=path, sep="\n")
 }
 
@@ -34,6 +35,7 @@ verify_web_output <- function(){
   
   date_results <- list()
   
+  print("Verifying plots and fixing fonts")
   for(country in countries) {
     for (plot_version in plot_versions) {
       for (plot_name in plot_names) {
@@ -59,8 +61,11 @@ verify_web_output <- function(){
   web_fix_fonts("web/figures/desktop/covars-alpha-reduction.svg")
   web_fix_fonts("web/figures/mobile/covars-alpha-reduction.svg")
   
+  print("Writing latest updates")
   dir.create("web/data/", showWarnings = FALSE, recursive = TRUE)
   write_json(date_results, "web/data/latest-updates.json", auto_unbox=TRUE)
 }
 
+print("Verifying web output")
 verify_web_output()
+print("Web verification successful")


### PR DESCRIPTION
I've discussed the N2 as discussed with @s-mishra 

The CI workflow now uses the web-fetch-and-run instead of running with the data in the current data dir, since this fails with the current settings, while it does work with the latest data. The alternative would be to download the newest data and push it to the data dir here, making the build more stable. 

Added some logging to have more outputs for debugging runs inside the Docker image. And all system() calls now check the return code and let base.r fail if it isn't 0. 