### PR TITLE
Document mobility covariates normalisation

### DIFF
--- a/Italy/code/utils/process-covariates-italy.r
+++ b/Italy/code/utils/process-covariates-italy.r
@@ -230,43 +230,31 @@ process_covariates <- function(regions, mobility, intervention, d, ifr.by.countr
     stan_data$P_partial = 1
 
   # Normalise positive covariate effects to be between 0 and 1
-  dm=dim(stan_data$X)
-  for(j in 1:dm[3]){ # for covariates
-    for(i in 1:dm[1]){ # countries
-      raw=stan_data$X[i,,j]
-      if(all(raw!=0)){
-        top = raw[raw>=0]
-        bottom = raw[raw<=0]
-        adjusted=raw
-        # only act on real valued covariates (not the discrete interventions)
-        if(sum(top==1)!=length(top)){
-          top=rescale(top,to=c(0,1))
-          adjusted[raw>=0]=top
-        }
-        stan_data$X[i,,j] = adjusted
-      }
-    }
-  }
+  stan_data$X=normalise_covariate_array(stan_data$X)
   # Normalise positive pooled covariate effects to be between 0 and 1
-  dm=dim(stan_data$X_partial)
-  for(j in 1:dm[3]){ # for covariates
-    for(i in 1:dm[1]){ # countries
-      raw=stan_data$X_partial[i,,j]
-      if(all(raw!=0)){
-        top = raw[raw>=0]
-        bottom = raw[raw<=0]
-        adjusted=raw
-        # only act on real valued covariates (not the discrete interventions)
-        if(sum(top==1)!=length(top)){
-          top=rescale(top,to=c(0,1))
-          adjusted[raw>=0]=top
-        }
-        stan_data$X_partial[i,,j] = adjusted
-      }
-    }
-  }
-  
+  stan_data$X_partial=normalise_covariate_array(stan_data$X_partial)
   
   return(list("stan_data" = stan_data, "dates" = dates, "reported_cases"=reported_cases, "deaths_by_country" = deaths_by_country))
 }
 
+normalise_covariate_array <- function(covariate_array){
+  # Normalise positive covariate effects to be between 0 and 1
+  dm=dim(covariate_array)
+  for(j in 1:dm[3]){ # for covariates
+    for(i in 1:dm[1]){ # countries
+      raw=covariate_array[i,,j]
+      if(all(raw!=0)){
+        top = raw[raw>=0]
+        bottom = raw[raw<=0]
+        adjusted=raw
+        # only act on real valued covariates (not the discrete interventions)
+        if(sum(top==1)!=length(top)){
+          top=rescale(top,to=c(0,1))
+          adjusted[raw>=0]=top
+        }
+        covariate_array[i,,j] = adjusted
+      }
+    }
+  }
+  return(covariate_array)
+}

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,6 @@ dependencies:
   - r-gtable
   - r-ggrepel
   - r-scales
+  - r-tidyverse
 channels:
   - conda-forge


### PR DESCRIPTION
These commits do not alter behaviours of the code, they document and functionalise the normalisation steps taken on the covariate arrays.

+ 7fed945 is only comments and labels the steps
+ 316641e functionalises the normalisation process

 tidyverse was also found to be missing from the conda env to run `base-italy.r` and is added.

I'd be very interested in any comments on the steps taken and their rationale as some of it is unclear to me.