### PR TITLE
Added boost (BH) to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: covid19model
 dependencies:
+  - r-BH
   - r-bayesplot
   - r-data.table
   - r-envstats


### PR DESCRIPTION
Without this addition, I get a "Boost not found" error from Stan when running base.r.

```
$ Rscript base.r base
…<snip>...
[1] "First non-zero cases is on day 60, and 30 days before 10 deaths is day 46"
[1] "Netherlands has 71 days of data"
Error in stan_model(paste0("stan-models/", StanModel, ".stan")) : 
  Boost not found; call install.packages('BH')
Execution halted
```